### PR TITLE
add support for custom color palettes

### DIFF
--- a/src/styled-components-debugger.js
+++ b/src/styled-components-debugger.js
@@ -1,4 +1,4 @@
-import {getRandomColor} from './utils';
+import {getRandomColor, getPaletteColor} from './utils';
 
 const debugTemplateLiterals = (defaultParams = {}) => {
 
@@ -21,6 +21,9 @@ const debugTemplateLiterals = (defaultParams = {}) => {
             position                  = 1,
           }                           = mergedParams;
 
+    if (params.pretty) {
+      color = getPaletteColor(params.pretty)
+    }
     const displayText = showText === true && !!text;
     return `
       ${displayText && `position: relative`};

--- a/src/utils.js
+++ b/src/utils.js
@@ -6,3 +6,14 @@ export const getRandomColor = () => {
   }
   return color;
 }
+
+var colorIndex = 0
+const materialPalette = [ '#F44336', '#E91E63', '#9C27B0', '#673AB7', '#3F51B5', '#2196F3', '#03A9F4', '#00BCD4', '#009688', '#4CAF50', '#8BC34A', '#CDDC39', '#FFEB3B', '#FFC107', '#FF9800', '#FF5722', '#795548', '#9E9E9E', '#607D8B',]
+
+export const getPaletteColor = (palette)=> {
+  if (!Array.isArray(palette)) {
+    palette = materialPalette
+  }
+  colorIndex++;
+  return palette[colorIndex % colors.length];
+}


### PR DESCRIPTION
Basically, this adds the possibility to choose colors randomly from a **custom color palette**, either provided by the user (as an array of colors) or we could provide a few custom ones
What do you think about this feature? I was already working with in [this gist](https://gist.github.com/haikyuu/25be4fc0e8126292d3bede9d03995dae).

I brought the colors from http://materialuicolors.co/

This feature would be very pleasing to the eye especially for background  debugging.
What are your thoughts @kitze ? 